### PR TITLE
chore(server): Rename `GH_TOKEN` to `PROVIDER_TOKEN_GITHUB`.

### DIFF
--- a/main.go
+++ b/main.go
@@ -14,7 +14,7 @@ func main() {
 		Router: mux.NewRouter(),
 		Logger: slog.New(slog.NewTextHandler(os.Stderr, nil)),
 		GitHub: GitHub{
-			Token: os.Getenv("GH_TOKEN"),
+			Token: os.Getenv("PROVIDER_TOKEN_GITHUB"),
 		},
 	}
 


### PR DESCRIPTION
`GH_TOKEN` conflicts with GitHub's CLI environment: https://cli.github.com/manual/gh_help_environment.

#18 